### PR TITLE
Fixed empty payload for testPostPublish refused by some servers

### DIFF
--- a/src/Moxl/Stanza/Pubsub.php
+++ b/src/Moxl/Stanza/Pubsub.php
@@ -188,7 +188,9 @@ class Pubsub {
         $xml = '
             <pubsub xmlns="http://jabber.org/protocol/pubsub">
                 <publish node="'.$node.'">
-                    <item id="'.$id.'"/>
+                    <item id="'.$id.'">
+			<entry xmlns="http://www.w3.org/2005/Atom"/>
+                    </item>
                 </publish>
             </pubsub>';
         $xml = \Moxl\API::iqWrapper($xml, $to, 'set');


### PR DESCRIPTION
Ejabberd was rejecting submissions with an empty payload. It works with a empty Atom entry as payload instead.