### PR TITLE
Use XHTML for rich content instead of HTML in Atom

### DIFF
--- a/src/Moxl/Stanza/PubsubAtom.php
+++ b/src/Moxl/Stanza/PubsubAtom.php
@@ -10,7 +10,7 @@ class PubsubAtom {
     public $title;
     public $link;
     public $image;
-    public $contenthtml = false;
+    public $contentxhtml = false;
 
     public $to;
     public $node;
@@ -89,16 +89,12 @@ class PubsubAtom {
                     </geoloc>';
         }
 
-        if($this->contenthtml)
+        if($this->contentxhtml)
             $xml .= '
                 <content type="xhtml">
-                    <![CDATA[
-                        <html xmlns="http://jabber.org/protocol/xhtml-im">
-                            <body xmlns="http://www.w3.org/1999/xhtml">
-                                '.$this->contenthtml.'
-                            </body>
-                        </html>
-                    ]]>
+                    <div xmlns="http://www.w3.org/1999/xhtml">
+                        '.$this->contentxhtml.'
+                    </div>
                 </content>';
         $xml .= '
                 <content type="text">'.$this->content.'</content>';

--- a/src/Moxl/Xec/Action/Pubsub/PostPublish.php
+++ b/src/Moxl/Xec/Action/Pubsub/PostPublish.php
@@ -98,9 +98,9 @@ class PostPublish extends Errors
         return $this;
     }
 
-    public function setContentHtml($content)
+    public function setContentXhtml($content)
     {
-        $this->_atom->contenthtml = $content;
+        $this->_atom->contentxhtml = $content;
         return $this;
     }
 


### PR DESCRIPTION
This allows any client to directly use the XHTML parsed by their XMPP parser, instead of redoing a second pass with another parser.